### PR TITLE
Range negative step warning silencing

### DIFF
--- a/lib/magic.ex
+++ b/lib/magic.ex
@@ -112,7 +112,7 @@ defmodule ExMarcel.Magic do
     mime =
       case ext |> String.slice(0..0) do
         "." ->
-          ext = ext |> String.slice(1..-1)
+          ext = ext |> String.slice(1..-1//-1)
           TableWrapper.extensions() |> Map.get(ext)
 
         _ ->


### PR DESCRIPTION
With recent Elixir versions there are warnings emitted about default negative step being used. While this warning could be safely ignored, it is still better not to have it littering the output.